### PR TITLE
feat: install `grafana`, `dlv`,  `yq` and `tomlq`

### DIFF
--- a/roles/golang/defaults/main.yml
+++ b/roles/golang/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
-go_version: "1.20.7"
+go_version: "1.21.6"  # https://go.dev/dl/
+dlv_version: "1.22.0" # https://github.com/go-delve/delve/releases

--- a/roles/golang/tasks/main.yml
+++ b/roles/golang/tasks/main.yml
@@ -38,3 +38,10 @@
       ansible.builtin.lineinfile:
         path: /etc/bash.bashrc
         line: export PATH=$PATH:/opt/go/bin
+
+- name: Install dlv
+  ansible.builtin.shell:
+    cmd: go install github.com/go-delve/delve/cmd/dlv@{{ dlv_version }}
+  args:
+    executable: /bin/bash
+    creates: "{{ ansible_env.GOBIN }}/dlv"

--- a/roles/golang/tasks/main.yml
+++ b/roles/golang/tasks/main.yml
@@ -37,11 +37,11 @@
     - name: Add go to the path
       ansible.builtin.lineinfile:
         path: /etc/bash.bashrc
-        line: export PATH=$PATH:/opt/go/bin
+        line: export PATH=$PATH:/opt/go/bin:$HOME/go/bin
 
 - name: Install dlv
   ansible.builtin.shell:
-    cmd: go install github.com/go-delve/delve/cmd/dlv@{{ dlv_version }}
+    cmd: go install github.com/go-delve/delve/cmd/dlv@v{{ dlv_version }}
   args:
     executable: /bin/bash
-    #creates: "{{ ansible_env.GOBIN }}/dlv"
+    creates: $HOME/go/bin/dlv

--- a/roles/golang/tasks/main.yml
+++ b/roles/golang/tasks/main.yml
@@ -44,4 +44,4 @@
     cmd: go install github.com/go-delve/delve/cmd/dlv@{{ dlv_version }}
   args:
     executable: /bin/bash
-    creates: "{{ ansible_env.GOBIN }}/dlv"
+    #creates: "{{ ansible_env.GOBIN }}/dlv"

--- a/roles/golang/tasks/main.yml
+++ b/roles/golang/tasks/main.yml
@@ -22,6 +22,11 @@
         creates: /opt/go-{{ go_version }}/go
         remote_src: true
 
+    - name: Clean up
+      ansible.builtin.file:
+        path: /opt/go{{ go_version }}.tar.gz
+        state: absent
+
     - name: Create a symlink for current go
       ansible.builtin.file:
         src: /opt/go-{{ go_version }}/go

--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+grafana_version: "10.3.1"

--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-grafana_version: "10.3.1"
+grafana_version: "10.3.1" # https://github.com/grafana/grafana/releases

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -18,8 +18,13 @@
     - name: Extract grafana {{ grafana_version }} binary
       ansible.builtin.unarchive:
         src: /opt/grafana-{{ grafana_version }}.linux-amd64.tar.gz
-        dest: /opt/grafana-v{{ grafana_version }}
+        dest: /opt
         remote_src: true
+
+    - name: Clean up
+      ansible.builtin.file:
+        path: /opt/grafana-{{ grafana_version }}.linux-amd64.tar.gz
+        state: absent
 
     - name: Install Grafana binaries to local bin
       ansible.builtin.copy:

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+
+- name: Install Grafana
+  block:
+    - name: Create directory for grafana {{ grafana_version }}
+      ansible.builtin.file:
+        path: /opt/grafana-v{{ grafana_version }}
+        state: directory
+        owner: root
+        group: root
+
+    - name: Download grafana {{ grafana_version }}
+      ansible.builtin.get_url:
+        url: https://dl.grafana.com/oss/release/grafana-{{ grafana_version }}.linux-amd64.tar.gz
+        dest: /opt/grafana-{{ grafana_version }}.linux-amd64.tar.gz
+        mode: "0644"
+
+    - name: Extract grafana {{ grafana_version }} binary
+      ansible.builtin.unarchive:
+        src: /opt/grafana-{{ grafana_version }}.tar.gz
+        dest: /opt/grafana-v{{ grafana_version }}
+        #creates: /opt/grafana-{{ grafana_version }}
+        remote_src: true
+
+    - name: Install Grafana binaries to local bin
+      ansible.builtin.copy:
+        src: /opt/grafana-v{{ grafana_version }}/bin/{{ item }}
+        dest: /usr/local/bin/{{ item }}
+        mode: "0755"
+        remote_src: true
+      loop:
+        - grafana
+        - grafana-cli
+        - grafana-server

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -28,11 +28,7 @@
 
     - name: Install Grafana binaries to local bin
       ansible.builtin.copy:
-        src: /opt/grafana-v{{ grafana_version }}/bin/{{ item }}
-        dest: /usr/local/bin/{{ item }}
+        src: /opt/grafana-v{{ grafana_version }}/bin/grafana
+        dest: /usr/local/bin/grafana
         mode: "0755"
         remote_src: true
-      loop:
-        - grafana
-        - grafana-cli
-        - grafana-server

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -17,9 +17,8 @@
 
     - name: Extract grafana {{ grafana_version }} binary
       ansible.builtin.unarchive:
-        src: /opt/grafana-{{ grafana_version }}.tar.gz
+        src: /opt/grafana-{{ grafana_version }}.linux-amd64.tar.gz
         dest: /opt/grafana-v{{ grafana_version }}
-        #creates: /opt/grafana-{{ grafana_version }}
         remote_src: true
 
     - name: Install Grafana binaries to local bin

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -48,7 +48,7 @@
     state: present
     update_cache: true
 
-- name: systemwide emacs setup
+- name: Systemwide emacs setup
   block:
     - name: Emacs with no window by default
       ansible.builtin.lineinfile:
@@ -72,4 +72,3 @@
       ansible.builtin.lineinfile:
         path: "/etc/bash.bashrc"
         line: "[[ $- = *i* ]] && source /usr/local/share/liquidprompt/liquidprompt"
-

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -48,16 +48,11 @@
     state: present
     update_cache: true
 
-- name: Install yq
-  ansible.builtin.get_url:
-    url: https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-    dest: /usr/bin/yq
-    mode: "0755"
-    force: yes
-
-- name: Install tomlq
+- name: Install python packages
   ansible.builtin.pip:
-    name: tomlq
+    name:
+      - tomlq
+      - yq
     executable: pip3
     state: present
 

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -48,6 +48,19 @@
     state: present
     update_cache: true
 
+- name: Install yq
+  ansible.builtin.get_url:
+    url: https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+    dest: /usr/bin/yq
+    mode: "0755"
+    force: yes
+
+- name: Install tomlq
+  ansible.builtin.pip:
+    name: tomlq
+    executable: pip3
+    state: present
+
 - name: Systemwide emacs setup
   block:
     - name: Emacs with no window by default

--- a/roles/polycli/tasks/main.yml
+++ b/roles/polycli/tasks/main.yml
@@ -1,27 +1,25 @@
 ---
 - name: Install Polygon CLI
   block:
-    - name: Clone Polycli
+    - name: Clone polycli {{ polygon_cli_version }}
       ansible.builtin.git:
         repo: https://github.com/maticnetwork/polygon-cli.git
         dest: /opt/polygon-cli
         version: "{{ polygon_cli_version }}"
         recursive: true
 
-    - name: Build polycli
+    - name: Build polycli {{ polygon_cli_version }}
       ansible.builtin.shell: |
-        pushd /opt/polygon-cli
         make clean
         make build
-        popd
       args:
         executable: /bin/bash
+        chdir: /opt/polygon-cli
         creates: /opt/polygon-cli/out/polycli
 
-    - name: Install polycli to local bin
+    - name: Install polycli {{ polygon_cli_version }} to local bin
       ansible.builtin.copy:
         src: /opt/polygon-cli/out/polycli
         dest: /usr/local/bin/polycli
         mode: "0755"
         remote_src: true
-


### PR DESCRIPTION
## Description

- Bundle `grafana` into the blockchain.tools repository (https://polygon.atlassian.net/browse/DVT-1109).
- Install `dlv`, `yq` and `tomlq`.
- Bump `go` version.

## Test

```bash
[leovct@test-blockchain-tools-collection:~] $ grafana --version
grafana version 10.3.1

[leovct@test-blockchain-tools-collection:~] $ dlv version
Delve Debugger
Version: 1.22.0
Build: $Id: 61ecdbbe1b574f0dd7d7bad8b6a5d564cce981e9 $

[leovct@test-blockchain-tools-collection:~] $ tomlq --version
tomlq 3.2.3

[leovct@test-blockchain-tools-collection:~] $ yq --version
yq 3.2.3

[leovct@test-blockchain-tools-collection:~] $ go version
go version go1.21.6 linux/amd64
```
